### PR TITLE
Fix Searchbar Parameter Bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
         <span class="slogan"><?php echo $Site->slogan() ?></span>
     </span>
     <!-- Search -->
-    <form role="search" action="<?php echo $Site->url() . 'search.php';?>" target="_blank">
+    <form role="search" action="<?php echo $Site->url() . (substr($Site->url(), -1) == '/' ? '' : '/') . 'search.php';?>" target="_blank">
         <input type="text" name="q" class="form-control" placeholder="Search...">
     </form>
 </header>


### PR DESCRIPTION
If the site url has not an ending slash, the search bar will mislead the request. This check will avoid the error.